### PR TITLE
Allow multiple keys in GroupBy

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1108,6 +1108,81 @@ Purchase.select
 
 
 
+### Select.groupBy.multipleKeys
+
+
+
+```scala
+Purchase.select.groupBy(x => (x.shippingInfoId, x.productId))(_.sumBy(_.total))
+```
+
+
+*
+    ```sql
+    SELECT
+      purchase0.shipping_info_id AS res_0_0,
+      purchase0.product_id AS res_0_1,
+      SUM(purchase0.total) AS res_1
+    FROM 
+      purchase purchase0
+    GROUP BY
+      purchase0.shipping_info_id,
+      purchase0.product_id
+    ```
+
+
+
+*
+    ```scala
+    Seq(
+      ((1, 1), 888.0),
+      ((1, 2), 900.0),
+      ((1, 3), 15.7),
+      ((2, 4), 493.8),
+      ((2, 5), 10000.0),
+      ((3, 1), 44.4),
+      ((3, 6), 1.3)
+    )
+    ```
+
+
+
+### Select.groupBy.multipleKeysHaving
+
+
+
+```scala
+Purchase.select
+  .groupBy(x => (x.shippingInfoId, x.productId))(_.sumBy(_.total))
+  .filter(_._2 > 10)
+  .filter(_._2 < 100)
+```
+
+
+*
+    ```sql
+    SELECT
+      purchase0.shipping_info_id AS res_0_0,
+      purchase0.product_id AS res_0_1,
+      SUM(purchase0.total) AS res_1
+    FROM 
+      purchase purchase0
+    GROUP BY
+      purchase0.shipping_info_id,
+      purchase0.product_id
+    HAVING 
+      (SUM(purchase0.total) > ?) AND (SUM(purchase0.total) < ?)
+    ```
+
+
+
+*
+    ```scala
+    Seq(((1, 3), 15.7), ((3, 1), 44.4))
+    ```
+
+
+
 ### Select.distinct.nondistinct
 
 Normal queries can allow duplicates in the returned row values, as seen below.

--- a/scalasql/query/src/Model.scala
+++ b/scalasql/query/src/Model.scala
@@ -40,7 +40,7 @@ object Nulls {
 /**
  * Models a SQL `GROUP BY` clause
  */
-case class GroupBy(key: Expr[?], select: () => Select[?, ?], having: Seq[Expr[?]])
+case class GroupBy(keys: Seq[Expr[?]], select: () => Select[?, ?], having: Seq[Expr[?]])
 
 /**
  * Models a SQL `JOIN` clause

--- a/scalasql/test/src/WorldSqlTests.scala
+++ b/scalasql/test/src/WorldSqlTests.scala
@@ -205,54 +205,6 @@ object WorldSqlTests extends TestSuite {
       // -DOCS
     }
 
-    test("groupByMultipleFields") {
-      val query = City.select.groupBy { t => (t.id, t.countryCode) }(_.sumBy(_.population))
-
-      db.renderSql(query) ==> """
-      SELECT 
-        city0.id AS res_0_0, 
-        city0.countrycode AS res_0_1, 
-        SUM(city0.population) AS res_1 
-      FROM 
-        city city0 
-      GROUP BY 
-        city0.id, 
-        city0.countrycode
-      """
-
-      db.run(query).take(3) ==> Seq(
-        ((1, "AFG"), 1780000),
-        ((2, "AFG"), 237500),
-        ((3, "AFG"), 186800)
-      )
-    }
-
-    test("groupByMultipleFieldsWithFilter") {
-      val query = City.select
-        .groupBy { t => (t.id, t.countryCode) }(_.sumBy(_.population))
-        .filter(_._2 > 1000000)
-        .filter(_._2 < 2000000)
-
-      db.renderSql(query) ==> """
-      SELECT 
-        city0.id AS res_0_0, 
-        city0.countrycode AS res_0_1, 
-        SUM(city0.population) AS res_1 
-      FROM 
-        city city0 
-      GROUP BY 
-        city0.id, 
-        city0.countrycode
-      HAVING (SUM(city0.population) > ?) AND (SUM(city0.population) < ?)
-      """
-
-      db.run(query).take(3) ==> Seq(
-        ((1, "AFG"), 1780000),
-        ((70, "ARG"), 1266461),
-        ((71, "ARG"), 1157507)
-      )
-    }
-
     test("filter") {
 
       test("singleName") {


### PR DESCRIPTION
This pull request extends the GroupBy class so it can use multiple fields as keys. 
I've also added two tests to make sure it works fine and that I did not break filtering (HAVING) feature.
Fixes #52