### PR TITLE
JoinNullable deserialisation fix

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9838,6 +9838,32 @@ db.run(Enclosing.select) ==> Seq(value1, value2)
 
 
 
+### DataTypes.JoinNullable proper type mapping
+
+
+
+```scala
+case class A[T[_]](id: T[Int], bId: T[Option[Int]])
+object A extends Table[A]
+
+object Custom extends Enumeration {
+  val Foo, Bar = Value
+
+  implicit def make: String => Value = withName
+}
+
+case class B[T[_]](id: T[Int], custom: T[Custom.Value])
+object B extends Table[B]
+db.run(A.insert.columns(_.id := 1, _.bId := None))
+val result = db.run(A.select.leftJoin(B)(_.id === _.id).single)
+result._2 ==> None
+```
+
+
+
+
+
+
 ## Optional
 Queries using columns that may be `NULL`, `Expr[Option[T]]` or `Option[T]` in Scala
 ### Optional

--- a/scalasql/core/src/Queryable.scala
+++ b/scalasql/core/src/Queryable.scala
@@ -68,6 +68,14 @@ object Queryable {
     var nulls = 0
     var nonNulls = 0
 
+    def restAreNulls(columnsCount: Int): Boolean = {
+      val result = Range.inclusive(index + 1, index + columnsCount).map { i =>
+        r.getObject(i) == null
+      }.forall(identity)
+      if(result) index = index + columnsCount
+      result
+    }
+
     def get[T](mt: TypeMapper[T]) = {
       index += 1
       val res = mt.get(r, index)
@@ -143,10 +151,11 @@ object Queryable {
       def walkExprs(q: JoinNullable[Q]) = qr.walkExprs(q.get)
 
       def construct(args: Queryable.ResultSetIterator): Option[R] = {
-        val startNonNulls = args.nonNulls
-        val res = qr.construct(args)
-        if (startNonNulls == args.nonNulls) None
-        else Option(res)
+        if(args.restAreNulls(qr.walkLabels().length)) {
+          None
+        } else {
+          Option(qr.construct(args))
+        }
       }
 
       def deconstruct(r: Option[R]): JoinNullable[Q] = JoinNullable(qr.deconstruct(r.get))

--- a/scalasql/core/src/Queryable.scala
+++ b/scalasql/core/src/Queryable.scala
@@ -69,10 +69,10 @@ object Queryable {
     var nonNulls = 0
 
     def restAreNulls(columnsCount: Int): Boolean = {
-      val result = Range.inclusive(index + 1, index + columnsCount).map { i =>
+      val result = Range.inclusive(index + 1, index + columnsCount).forall { i =>
         r.getObject(i) == null
-      }.forall(identity)
-      if(result) index = index + columnsCount
+      }
+      if (result) index = index + columnsCount
       result
     }
 
@@ -151,7 +151,7 @@ object Queryable {
       def walkExprs(q: JoinNullable[Q]) = qr.walkExprs(q.get)
 
       def construct(args: Queryable.ResultSetIterator): Option[R] = {
-        if(args.restAreNulls(qr.walkLabels().length)) {
+        if (args.restAreNulls(qr.walkLabels().length)) {
           None
         } else {
           Option(qr.construct(args))

--- a/scalasql/core/src/Queryable.scala
+++ b/scalasql/core/src/Queryable.scala
@@ -68,7 +68,7 @@ object Queryable {
     var nulls = 0
     var nonNulls = 0
 
-    def restAreNulls(columnsCount: Int): Boolean = {
+    def consumeNulls(columnsCount: Int): Boolean = {
       val result = Range.inclusive(index + 1, index + columnsCount).forall { i =>
         r.getObject(i) == null
       }
@@ -151,7 +151,7 @@ object Queryable {
       def walkExprs(q: JoinNullable[Q]) = qr.walkExprs(q.get)
 
       def construct(args: Queryable.ResultSetIterator): Option[R] = {
-        if (args.restAreNulls(qr.walkLabels().length)) {
+        if (args.consumeNulls(qr.walkLabels().length)) {
           None
         } else {
           Option(qr.construct(args))

--- a/scalasql/src/dialects/Dialect.scala
+++ b/scalasql/src/dialects/Dialect.scala
@@ -228,8 +228,7 @@ trait Dialect extends DialectTypeMappers {
     def jdbcType: JDBCType = JDBCType.VARCHAR
     def get(r: ResultSet, idx: Int): T = {
       val str = r.getString(idx)
-      if (str == null) null.asInstanceOf[T]
-      else constructor(str)
+      constructor(str)
     }
     def put(r: PreparedStatement, idx: Int, v: T) =
       r.setObject(idx, v, java.sql.Types.OTHER)

--- a/scalasql/test/resources/h2-customer-schema.sql
+++ b/scalasql/test/resources/h2-customer-schema.sql
@@ -3,6 +3,8 @@ DROP TABLE IF EXISTS product CASCADE;
 DROP TABLE IF EXISTS shipping_info CASCADE;
 DROP TABLE IF EXISTS purchase CASCADE;
 DROP TABLE IF EXISTS data_types CASCADE;
+DROP TABLE IF EXISTS a CASCADE;
+DROP TABLE IF EXISTS b CASCADE;
 DROP TABLE IF EXISTS non_round_trip_types CASCADE;
 DROP TABLE IF EXISTS opt_cols CASCADE;
 DROP TABLE IF EXISTS nested CASCADE;
@@ -56,6 +58,16 @@ CREATE TABLE data_types (
     my_uuid UUID,
     my_enum VARCHAR(256)
 --     my_offset_time TIME WITH TIME ZONE,
+);
+
+CREATE TABLE a(
+    id INTEGER,
+    b_id INTEGER
+);
+
+CREATE TABLE b(
+    id INTEGER,
+    custom VARCHAR(256)
 );
 
 CREATE TABLE non_round_trip_types(

--- a/scalasql/test/resources/mysql-customer-schema.sql
+++ b/scalasql/test/resources/mysql-customer-schema.sql
@@ -4,6 +4,8 @@ DROP TABLE IF EXISTS `product` CASCADE;
 DROP TABLE IF EXISTS `shipping_info` CASCADE;
 DROP TABLE IF EXISTS `purchase` CASCADE;
 DROP TABLE IF EXISTS `data_types` CASCADE;
+DROP TABLE IF EXISTS `a` CASCADE;
+DROP TABLE IF EXISTS `b` CASCADE;
 DROP TABLE IF EXISTS `non_round_trip_types` CASCADE;
 DROP TABLE IF EXISTS `opt_cols` CASCADE;
 DROP TABLE IF EXISTS `nested` CASCADE;
@@ -55,6 +57,16 @@ CREATE TABLE data_types (
     my_var_binary VARBINARY(256),
     my_uuid CHAR(36),
     my_enum ENUM ('foo', 'bar', 'baz')
+);
+
+CREATE TABLE a(
+    id INTEGER,
+    b_id INTEGER
+);
+
+CREATE TABLE b(
+    id INTEGER,
+    custom VARCHAR(256)
 );
 
 CREATE TABLE non_round_trip_types(

--- a/scalasql/test/resources/postgres-customer-schema.sql
+++ b/scalasql/test/resources/postgres-customer-schema.sql
@@ -3,6 +3,8 @@ DROP TABLE IF EXISTS product CASCADE;
 DROP TABLE IF EXISTS shipping_info CASCADE;
 DROP TABLE IF EXISTS purchase CASCADE;
 DROP TABLE IF EXISTS data_types CASCADE;
+DROP TABLE IF EXISTS a CASCADE;
+DROP TABLE IF EXISTS b CASCADE;
 DROP TABLE IF EXISTS non_round_trip_types CASCADE;
 DROP TABLE IF EXISTS opt_cols CASCADE;
 DROP TABLE IF EXISTS nested CASCADE;
@@ -59,6 +61,16 @@ CREATE TABLE data_types (
     my_enum my_enum
 --     my_offset_time TIME WITH TIME ZONE,
 
+);
+
+CREATE TABLE a(
+    id INTEGER,
+    b_id INTEGER
+);
+
+CREATE TABLE b(
+    id INTEGER,
+    custom VARCHAR(256)
 );
 
 CREATE TABLE non_round_trip_types(

--- a/scalasql/test/resources/sqlite-customer-schema.sql
+++ b/scalasql/test/resources/sqlite-customer-schema.sql
@@ -3,6 +3,8 @@ DROP TABLE IF EXISTS product;
 DROP TABLE IF EXISTS shipping_info;
 DROP TABLE IF EXISTS purchase;
 DROP TABLE IF EXISTS data_types;
+DROP TABLE IF EXISTS a;
+DROP TABLE IF EXISTS b;
 DROP TABLE IF EXISTS non_round_trip_types;
 DROP TABLE IF EXISTS nested;
 DROP TABLE IF EXISTS enclosing;
@@ -54,6 +56,16 @@ CREATE TABLE data_types (
     my_uuid BINARY(16),
     my_enum VARCHAR(256)
 --     my_offset_time TIME WITH TIME ZONE,
+);
+
+CREATE TABLE a(
+    id INTEGER,
+    b_id INTEGER
+);
+
+CREATE TABLE b(
+    id INTEGER,
+    custom VARCHAR(256)
 );
 
 CREATE TABLE non_round_trip_types(

--- a/scalasql/test/src/datatypes/DataTypesTests.scala
+++ b/scalasql/test/src/datatypes/DataTypesTests.scala
@@ -212,5 +212,25 @@ trait DataTypesTests extends ScalaSqlSuite {
 
       }
     )
+    test("JoinNullable proper type mapping") - checker.recorded(
+      "???",
+      Text {
+        case class A[T[_]](id: T[Int], bId: T[Option[Int]])
+        object A extends Table[A]
+
+        object Custom extends Enumeration {
+          val Foo, Bar = Value
+
+          implicit def make: String => Value = withName
+          // implicit val mapper: TypeMapper[Custom.Value] = StringType.bimap(_.toString, Custom.withName)
+        }
+
+        case class B[T[_]](id: T[Int], custom: T[Custom.Value])
+        object B extends Table[B]
+        db.run(A.insert.columns(_.id := 1, _.bId := None))
+        val result = db.run(A.select.leftJoin(B)(_.id === _.id).single)
+        result._2 ==> None
+      }
+    )
   }
 }

--- a/scalasql/test/src/datatypes/DataTypesTests.scala
+++ b/scalasql/test/src/datatypes/DataTypesTests.scala
@@ -213,7 +213,7 @@ trait DataTypesTests extends ScalaSqlSuite {
       }
     )
     test("JoinNullable proper type mapping") - checker.recorded(
-      "???",
+      "",
       Text {
         case class A[T[_]](id: T[Int], bId: T[Option[Int]])
         object A extends Table[A]
@@ -222,7 +222,6 @@ trait DataTypesTests extends ScalaSqlSuite {
           val Foo, Bar = Value
 
           implicit def make: String => Value = withName
-          // implicit val mapper: TypeMapper[Custom.Value] = StringType.bimap(_.toString, Custom.withName)
         }
 
         case class B[T[_]](id: T[Int], custom: T[Custom.Value])


### PR DESCRIPTION
In the current implementation, JoinNullable in order to determine that R shouldBe Option or Some is deserialising whole set and then counting nulls. In cases where you have user written TypeMapper, that doesn't do nulls tricks(like inside Dialects.scala), such:
```
enum Enumeration {
 case A, B, C
}
object Enumeration {
 given TypeMapper[Enumeration] = StringType.bimap(_.toString(), Enumeration.valueOf)
}
```
then leftJoin query, where the right side can be nullable instead of returning (A, None) will fail with exception, check new test in DataTypesTests

new implementation will check first if the rest of columns are null without deserialising them into type and only if one of them is not - will try to construct

comments on everything are welcome!

fixes #65 

