### PR TITLE
Add TransactionListener interface

### DIFF
--- a/scalasql/core/src/DbApi.scala
+++ b/scalasql/core/src/DbApi.scala
@@ -137,6 +137,45 @@ object DbApi {
   }
 
   /**
+   * A listener that can be added to a [[DbApi.Txn]] to be notified of commit and rollback events.
+   *
+   * The default implementations of these methods do nothing, but you can override them to
+   * implement your own behavior.
+   */
+  trait TransactionListener {
+
+    /**
+     * Called before the transaction is committed.
+     *
+     * If this method throws an exception, the transaction will be rolled back and the exception
+     * will be propagated.
+     */
+    def beforeCommit(): Unit = ()
+
+    /**
+     * Called after the transaction is committed.
+     *
+     * If this method throws an exception, it will be propagated.
+     */
+    def afterCommit(): Unit = ()
+
+    /**
+     * Called before the transaction is rolled back.
+     *
+     * If this method throws an exception, the transaction will be rolled back and the exception
+     * will be propagated to the caller of rollback().
+     */
+    def beforeRollback(): Unit = ()
+
+    /**
+     * Called after the transaction is rolled back.
+     *
+     * If this method throws an exception, it will be propagated to the caller of rollback().
+     */
+    def afterRollback(): Unit = ()
+  }
+
+  /**
    * An interface to a SQL database *transaction*, allowing you to run queries,
    * create savepoints, or roll back the transaction.
    */
@@ -151,9 +190,11 @@ object DbApi {
     def savepoint[T](block: DbApi.Savepoint => T): T
 
     /**
-     * Tolls back any active Savepoints and then rolls back this Transaction
+     * Rolls back any active Savepoints and then rolls back this Transaction
      */
     def rollback(): Unit
+
+    def addTransactionListener(listener: TransactionListener): Unit
   }
 
   /**
@@ -187,9 +228,16 @@ object DbApi {
       connection: java.sql.Connection,
       config: Config,
       dialect: DialectConfig,
-      autoCommit: Boolean,
-      rollBack0: () => Unit
+      autoCommit: Boolean
   ) extends DbApi.Txn {
+    val listeners = collection.mutable.ArrayDeque.empty[TransactionListener]
+
+    override def addTransactionListener(listener: TransactionListener): Unit = {
+      if (autoCommit)
+        throw new IllegalStateException("Cannot add listener to auto-commit transaction")
+      listeners.append(listener)
+    }
+
     def run[Q, R](query: Q, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
         implicit qr: Queryable[Q, R],
         fileName: sourcecode.FileName,
@@ -218,6 +266,7 @@ object DbApi {
           res.toVector.asInstanceOf[R]
         }
       }
+
     }
 
     def stream[Q, R](query: Q, fetchSize: Int = -1, queryTimeoutSeconds: Int = -1)(
@@ -229,8 +278,8 @@ object DbApi {
       streamFlattened0(
         r => {
           qr.asInstanceOf[Queryable[Q, R]].construct(query, r) match {
-            case s: Seq[R] => s.head
-            case r: R => r
+            case s: Seq[R] @unchecked => s.head
+            case r: R @unchecked => r
           }
         },
         flattened,
@@ -545,8 +594,13 @@ object DbApi {
     }
 
     def rollback() = {
-      savepointStack.clear()
-      rollBack0()
+      try {
+        listeners.foreach(_.beforeRollback())
+      } finally {
+        savepointStack.clear()
+        connection.rollback()
+        listeners.foreach(_.afterRollback())
+      }
     }
 
     private def cast[T](t: Any): T = t.asInstanceOf[T]

--- a/scalasql/test/src/api/TransactionTests.scala
+++ b/scalasql/test/src/api/TransactionTests.scala
@@ -578,8 +578,7 @@ trait TransactionTests extends ScalaSqlSuite {
     test("listener") {
       test("beforeCommit and afterCommit are called under normal circumstances") {
         val listener = new StubTransactionListener()
-        dbClient.addTransactionListener(listener)
-        dbClient.transaction { _ =>
+        dbClient.withTransactionListener(listener).transaction { _ =>
           // do nothing
         }
         listener.beginCalled ==> true

--- a/scalasql/test/src/api/TransactionTests.scala
+++ b/scalasql/test/src/api/TransactionTests.scala
@@ -579,7 +579,7 @@ trait TransactionTests extends ScalaSqlSuite {
       test("beforeCommit and afterCommit are called under normal circumstances") {
         val listener = new StubTransactionListener()
         dbClient.addTransactionListener(listener)
-        dbClient.transaction { implicit txn =>
+        dbClient.transaction { _ =>
           // do nothing
         }
         listener.beginCalled ==> true

--- a/scalasql/test/src/api/TransactionTests.scala
+++ b/scalasql/test/src/api/TransactionTests.scala
@@ -21,10 +21,15 @@ trait TransactionTests extends ScalaSqlSuite {
       throwOnBeforeRollback: Boolean = false,
       throwOnAfterRollback: Boolean = false
   ) extends DbApi.TransactionListener {
+    var beginCalled = false
     var beforeCommitCalled = false
     var afterCommitCalled = false
     var beforeRollbackCalled = false
     var afterRollbackCalled = false
+
+    override def begin(): Unit = {
+      beginCalled = true
+    }
 
     override def beforeCommit(): Unit = {
       beforeCommitCalled = true
@@ -573,9 +578,11 @@ trait TransactionTests extends ScalaSqlSuite {
     test("listener") {
       test("beforeCommit and afterCommit are called under normal circumstances") {
         val listener = new StubTransactionListener()
+        dbClient.addTransactionListener(listener)
         dbClient.transaction { implicit txn =>
-          txn.addTransactionListener(listener)
+          // do nothing
         }
+        listener.beginCalled ==> true
         listener.beforeCommitCalled ==> true
         listener.afterCommitCalled ==> true
         listener.beforeRollbackCalled ==> false

--- a/scalasql/test/src/utils/TestChecker.scala
+++ b/scalasql/test/src/utils/TestChecker.scala
@@ -6,7 +6,7 @@ import scalasql.query.SubqueryRef
 import scalasql.{DbClient, Queryable, Expr, UtestFramework}
 
 class TestChecker(
-    val dbClient: DbClient,
+    val dbClient: DbClient.DataSource,
     testSchemaFileName: String,
     testDataFileName: String,
     suiteName: String,


### PR DESCRIPTION
Add TransactionListener interface to support notification and conditional action based on {before, after} {commit, rollback} events.

### Use-Case

My present need is to dispatch events conditional on the commit of the current transaction.  Using a post-commit hook allows for sending a message (e.g. on a AWS SQS queue) only after the transaction commits.  This prevents race conditions where the message is picked up for processing before changes have been effected in the database and are visible to other parties.   (Concretely, sending a "User Created" event only after the user record has been persisted.)   

Of course this is possible without post-commit hooks, however hooks provide a modular abstraction that decouples the code (e.g. send message) from the specific commit point.  Transactional event listeners are a common pattern, and can be seen in other libraries such as the Spring Framework (see https://docs.spring.io/spring-framework/reference/data-access/transaction/event.html)

### Other Use-Cases

Hooks provide modularity to support decoupling in several other cases.

Before-Commit Hook
- Perform final validation checks before committing changes
-  Update aggregate or summary tables based on transactional changes
- Trigger notifications or events based on the impending commit

After Commit Hook
  - Clean up temporary resources used during the transaction
  - Update caches or search indexes with newly committed data
  - Trigger asynchronous processes based on successful commits *(already elaborated above)*

Before Rollback Hook
  - Log detailed information about the state leading to rollback
  - Notify relevant components/systems about the impending rollback
 - Eagerly release resources used during the transaction

After Rollback Hook
- Reset application state or clear caches affected by the rolled-back transaction
- Log or report on the reasons for rollback for analysis
- Trigger compensating actions or notifications due to the failed transaction
