### PR TITLE
Escape table in returning clause

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7061,6 +7061,41 @@ Select.insert.values(
 
 
 
+## EscapedTableNameWithReturning
+
+    If your table name is a reserved sql world, e.g. `order`, you can specify this in your table definition with
+    `override def escape = true`
+  
+### EscapedTableNameWithReturning.insert with returning
+
+
+
+```scala
+Select.insert
+  .values(
+    Select[Sc](
+      id = 0,
+      name = "hello"
+    )
+  )
+  .returning(_.id)
+```
+
+
+*
+    ```sql
+    INSERT INTO "select" (id, name) VALUES (?, ?) RETURNING "select".id AS res
+    ```
+
+
+
+*
+    ```scala
+    Seq(0)
+    ```
+
+
+
 ## SubQuery
 Queries that explicitly use subqueries (e.g. for `JOIN`s) or require subqueries to preserve the Scala semantics of the various operators
 ### SubQuery.sortTakeJoin

--- a/scalasql/query/src/Returning.scala
+++ b/scalasql/query/src/Returning.scala
@@ -54,7 +54,16 @@ object Returning {
     override def queryIsSingleRow = false
 
     private[scalasql] override def renderSql(ctx0: Context) = {
-      implicit val implicitCtx = Context.compute(ctx0, Nil, Some(returnable.table))
+      val contextStage1: Context = Context.compute(ctx0, Nil, Some(returnable.table))
+
+      implicit val implicitCtx: Context = if (returnable.table.value.escape) {
+        contextStage1.withFromNaming(
+          contextStage1.fromNaming
+            .updated(returnable.table, Table.fullIdentifier(returnable.table.value)(contextStage1))
+        )
+      } else {
+        contextStage1
+      }
 
       val prefix = Renderable.renderSql(returnable)
       val walked = qr.walkLabelsAndExprs(expr)

--- a/scalasql/test/src/ConcreteTestSuites.scala
+++ b/scalasql/test/src/ConcreteTestSuites.scala
@@ -30,7 +30,8 @@ import query.{
   GetGeneratedKeysTests,
   WithCteTests,
   SchemaTests,
-  EscapedTableNameTests
+  EscapedTableNameTests,
+  EscapedTableNameWithReturningTests
 }
 import scalasql.dialects.{
   MySqlDialectTests,
@@ -63,6 +64,9 @@ package postgres {
   object GetGeneratedKeysTests extends GetGeneratedKeysTests with PostgresSuite
   object SchemaTests extends SchemaTests with PostgresSuite
   object EscapedTableNameTests extends EscapedTableNameTests with PostgresSuite
+  object EscapedTableNameWithReturningTests
+      extends EscapedTableNameWithReturningTests
+      with PostgresSuite
 
   object SubQueryTests extends SubQueryTests with PostgresSuite
   object WithCteTests extends WithCteTests with PostgresSuite
@@ -109,6 +113,9 @@ package hikari {
   object GetGeneratedKeysTests extends GetGeneratedKeysTests with HikariSuite
   object SchemaTests extends SchemaTests with HikariSuite
   object EscapedTableNameTests extends EscapedTableNameTests with HikariSuite
+  object EscapedTableNameWithReturningTests
+      extends EscapedTableNameWithReturningTests
+      with HikariSuite
 
   object SubQueryTests extends SubQueryTests with HikariSuite
   object WithCteTests extends WithCteTests with HikariSuite
@@ -220,6 +227,9 @@ package sqlite {
   // Sqlite doesn't support schemas
   // object SchemaTests extends SchemaTests with SqliteSuite
   object EscapedTableNameTests extends EscapedTableNameTests with SqliteSuite
+  object EscapedTableNameWithReturningTests
+      extends EscapedTableNameWithReturningTests
+      with SqliteSuite
 
   object DataTypesTests extends datatypes.DataTypesTests with SqliteSuite
   object OptionalTests extends datatypes.OptionalTests with SqliteSuite

--- a/scalasql/test/src/query/EscapedTableNameReturningTests.scala
+++ b/scalasql/test/src/query/EscapedTableNameReturningTests.scala
@@ -1,0 +1,43 @@
+package scalasql.query
+
+import scalasql._
+import scalasql.core.JoinNullable
+import sourcecode.Text
+import utest._
+import utils.ScalaSqlSuite
+
+import java.time.LocalDate
+import scalasql.core.Config
+import scalasql.dialects.ReturningDialect
+
+trait EscapedTableNameWithReturningTests extends ScalaSqlSuite {
+  this: ReturningDialect =>
+
+  def description = """
+    If your table name is a reserved sql world, e.g. `order`, you can specify this in your table definition with
+    `override def escape = true`
+  """
+
+  def tests = Tests {
+    val tableNameEscaped = dialectSelf.escape(Config.camelToSnake(Table.name(Select)))
+
+    test("insert with returning") {
+      checker(
+        query = Text {
+          Select.insert
+            .values(
+              Select[Sc](
+                id = 0,
+                name = "hello"
+              )
+            )
+            .returning(_.id)
+        },
+        sql =
+          s"INSERT INTO $tableNameEscaped (id, name) VALUES (?, ?) RETURNING $tableNameEscaped.id AS res",
+        value = Seq(0),
+        docs = ""
+      )
+    }
+  }
+}


### PR DESCRIPTION
Similar issue to one i recently bumped into with update
I hope it's the last one, if I bump into one more - I either give up or rewrite general logic of computing table aliases 