### PR TITLE
Bump Sourcecode version so queries work in REPL

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -112,7 +112,7 @@ trait ScalaSql extends Common { common =>
   object core extends Common with CrossValue {
     def ivyDeps = Agg(
       ivy"com.lihaoyi::geny:1.0.0",
-      ivy"com.lihaoyi::sourcecode:0.3.1",
+      ivy"com.lihaoyi::sourcecode:0.4.2",
       ivy"com.lihaoyi::pprint:0.8.1"
     ) ++ Option.when(scalaVersion().startsWith("2."))(
       ivy"org.scala-lang:scala-reflect:${scalaVersion()}"


### PR DESCRIPTION
with scala 3.

citing Sourcecode release notes:
> 0.4.2
> Fix NullPointerException when using sourcecode.File in Scala 3 repl (https://github.com/com-lihaoyi/sourcecode/pull/161)
> Correctly handle backticked macro keyword in Scala 3 (https://github.com/com-lihaoyi/sourcecode/pull/163)