### PR TITLE
Add postgres json support

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -95,9 +95,9 @@ object `scalasql-simple` extends CommonBase {
 object scalasql extends Cross[ScalaSql](scalaVersions)
 trait ScalaSql extends Common { common =>
   def moduleDeps = Seq(query, operations)
-  def ivyDeps = Agg.empty[Dep] ++ Option.when(scalaVersion().startsWith("2."))(
-    ivy"org.scala-lang:scala-reflect:${scalaVersion()}"
-  )
+    def ivyDeps = Agg(ivy"com.lihaoyi::upickle:3.1.3") ++ Option.when(scalaVersion().startsWith("2."))(
+      ivy"org.scala-lang:scala-reflect:${scalaVersion()}"
+    )
 
   override def consoleScalacOptions: T[Seq[String]] = Seq("-Xprint:typer")
 

--- a/scalasql/src/dialects/PostgresDialect.scala
+++ b/scalasql/src/dialects/PostgresDialect.scala
@@ -47,6 +47,8 @@ trait PostgresDialect extends Dialect with ReturningDialect with OnConflictOps {
   implicit def ExprJsonOpsConv(v: Expr[ujson.Value]): PostgresDialect.ExprJsonOps =
     new PostgresDialect.ExprJsonOps(v)
 
+  implicit def UjsonQueryable: Queryable.Row[Expr[ujson.Value], ujson.Value] = ExprQueryable(UjsonValueType)
+
   override implicit def ExprBlobOpsConv(
       v: Expr[geny.Bytes]
   ): PostgresDialect.ExprStringLikeOps[geny.Bytes] =

--- a/scalasql/test/src/ConcreteTestSuites.scala
+++ b/scalasql/test/src/ConcreteTestSuites.scala
@@ -93,6 +93,7 @@ package postgres {
   object OptionalTests extends datatypes.OptionalTests with PostgresSuite
 
   object PostgresDialectTests extends PostgresDialectTests
+  object PostgresJsonTests extends scalasql.dialects.PostgresJsonTests
 
 }
 

--- a/scalasql/test/src/ExampleTests.scala
+++ b/scalasql/test/src/ExampleTests.scala
@@ -7,6 +7,7 @@ import utest._
 object ExampleTests extends TestSuite {
   def tests = Tests {
     test("postgres") - example.PostgresExample.main(Array())
+    test("postgresJson") - example.PostgresJsonExample.main(Array())
     test("mysql") - example.MySqlExample.main(Array())
     test("h2") - example.H2Example.main(Array())
     test("sqlite") - example.SqliteExample.main(Array())

--- a/scalasql/test/src/dialects/PostgresJsonTests.scala
+++ b/scalasql/test/src/dialects/PostgresJsonTests.scala
@@ -26,105 +26,111 @@ trait PostgresJsonTests extends ScalaSqlSuite with PostgresDialect {
 
   case class JsonTable[T[_]](id: T[Int], data: T[ujson.Value], dataJson: T[ujson.Value])
   object JsonTable extends Table[JsonTable] {
-     override def tableName = "json_table"
-     override def tableColumnNameOverride(s: String) = s match {
-       case "dataJson" => "data_json"
-       case s => s
-     }
+    override def tableName = "json_table"
+    override def tableColumnNameOverride(s: String) = s match {
+      case "dataJson" => "data_json"
+      case s => s
+    }
   }
 
   def tests = Tests {
-     test("access") - {
-         test("key") - check(
-            query = JsonTable.select.map(t => t.data -> "a"),
-            sql = "SELECT json_table0.data -> ? AS res FROM json_table json_table0"
-         )
-         test("index") - check(
-            query = JsonTable.select.map(t => t.data -> 0),
-            sql = "SELECT json_table0.data -> ? AS res FROM json_table json_table0"
-         )
-         test("keyText") - check(
-            query = JsonTable.select.map(t => t.data ->> "b"),
-            sql = "SELECT json_table0.data ->> ? AS res FROM json_table json_table0"
-         )
-         test("indexText") - check(
-            query = JsonTable.select.map(t => t.data ->> 1),
-            sql = "SELECT json_table0.data ->> ? AS res FROM json_table json_table0"
-         )
-         test("path") - check(
-            query = JsonTable.select.map(t => t.data #> "a"),
-            sql = "SELECT json_table0.data #> ARRAY[?] AS res FROM json_table json_table0"
-         )
-         test("pathText") - check(
-            query = JsonTable.select.map(t => t.data #>> "b"),
-            sql = "SELECT json_table0.data #>> ARRAY[?] AS res FROM json_table json_table0"
-         )
-     }
+    test("access") - {
+      test("key") - check(
+        query = JsonTable.select.map(t => t.data -> "a"),
+        sql = "SELECT json_table0.data -> ? AS res FROM json_table json_table0"
+      )
+      test("index") - check(
+        query = JsonTable.select.map(t => t.data -> 0),
+        sql = "SELECT json_table0.data -> ? AS res FROM json_table json_table0"
+      )
+      test("keyText") - check(
+        query = JsonTable.select.map(t => t.data ->> "b"),
+        sql = "SELECT json_table0.data ->> ? AS res FROM json_table json_table0"
+      )
+      test("indexText") - check(
+        query = JsonTable.select.map(t => t.data ->> 1),
+        sql = "SELECT json_table0.data ->> ? AS res FROM json_table json_table0"
+      )
+      test("path") - check(
+        query = JsonTable.select.map(t => t.data #> "a"),
+        sql = "SELECT json_table0.data #> ARRAY[?] AS res FROM json_table json_table0"
+      )
+      test("pathText") - check(
+        query = JsonTable.select.map(t => t.data #>> "b"),
+        sql = "SELECT json_table0.data #>> ARRAY[?] AS res FROM json_table json_table0"
+      )
+    }
 
-     test("contains") - {
-         test("right") - check(
-            query = JsonTable.select.filter(t => t.data @> ujson.Obj("a" -> 1)).map(_.id),
-            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE json_table0.data @> ?"
-         )
-         test("left") - check(
-            query = JsonTable.select.filter(t => t.data <@ ujson.Arr(1, 2, 3)).map(_.id),
-            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE json_table0.data <@ ?"
-         )
-     }
+    test("contains") - {
+      test("right") - check(
+        query = JsonTable.select.filter(t => t.data @> ujson.Obj("a" -> 1)).map(_.id),
+        sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE json_table0.data @> ?"
+      )
+      test("left") - check(
+        query = JsonTable.select.filter(t => t.data <@ ujson.Arr(1, 2, 3)).map(_.id),
+        sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE json_table0.data <@ ?"
+      )
+    }
 
-     test("exists") - {
-         test("key") - check(
-            query = JsonTable.select.filter(t => t.data ? "a").map(_.id),
-            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists(json_table0.data, ?)"
-         )
-         test("any") - check(
-            query = JsonTable.select.filter(t => t.data ?| ("a", "z")).map(_.id),
-            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists_any(json_table0.data, ARRAY[?, ?])"
-         )
-         test("all") - check(
-            query = JsonTable.select.filter(t => t.data ?& ("a", "b")).map(_.id),
-            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists_all(json_table0.data, ARRAY[?, ?])"
-         )
-     }
+    test("exists") - {
+      test("key") - check(
+        query = JsonTable.select.filter(t => t.data ? "a").map(_.id),
+        sql =
+          "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists(json_table0.data, ?)"
+      )
+      test("any") - check(
+        query = JsonTable.select.filter(t => t.data ?| ("a", "z")).map(_.id),
+        sql =
+          "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists_any(json_table0.data, ARRAY[?, ?])"
+      )
+      test("all") - check(
+        query = JsonTable.select.filter(t => t.data ?& ("a", "b")).map(_.id),
+        sql =
+          "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists_all(json_table0.data, ARRAY[?, ?])"
+      )
+    }
 
-     test("concat") - check(
-        query = JsonTable.select.filter(_.id === 1).map(t => t.data || ujson.Obj("c" -> 3)),
-        sql = "SELECT json_table0.data || ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
-     )
+    test("concat") - check(
+      query = JsonTable.select.filter(_.id === 1).map(t => t.data || ujson.Obj("c" -> 3)),
+      sql =
+        "SELECT json_table0.data || ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
+    )
 
-     test("delete") - {
-         test("key") - check(
-            query = JsonTable.select.filter(_.id === 1).map(t => t.data - "b"),
-            sql = "SELECT json_table0.data - ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
-         )
-         test("index") - check(
-            query = JsonTable.select.filter(_.id === 2).map(t => t.data - 1),
-            sql = "SELECT json_table0.data - ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
-         )
-     }
+    test("delete") - {
+      test("key") - check(
+        query = JsonTable.select.filter(_.id === 1).map(t => t.data - "b"),
+        sql =
+          "SELECT json_table0.data - ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
+      )
+      test("index") - check(
+        query = JsonTable.select.filter(_.id === 2).map(t => t.data - 1),
+        sql =
+          "SELECT json_table0.data - ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
+      )
+    }
 
-     test("json") - {
-         // Testing JSON type (non-binary)
-         test("access") - check(
-            query = JsonTable.select.map(t => t.dataJson -> "a"),
-            sql = "SELECT json_table0.data_json -> ? AS res FROM json_table json_table0"
-         )
-     }
+    test("json") - {
+      // Testing JSON type (non-binary)
+      test("access") - check(
+        query = JsonTable.select.map(t => t.dataJson -> "a"),
+        sql = "SELECT json_table0.data_json -> ? AS res FROM json_table json_table0"
+      )
+    }
 
-     test("insert") - {
-        test("simple") - {
-           val query = JsonTable.insert.values(
-               JsonTable(
-                   id = 3,
-                   data = ujson.Obj("x" -> 10),
-                   dataJson = ujson.Obj("y" -> 20)
-               )
-           )
-           check(
-               query,
-               "INSERT INTO json_table (id, data, data_json) VALUES (?, ?, ?)"
-           )
-        }
-     }
+    test("insert") - {
+      test("simple") - {
+        val query = JsonTable.insert.values(
+          JsonTable(
+            id = 3,
+            data = ujson.Obj("x" -> 10),
+            dataJson = ujson.Obj("y" -> 20)
+          )
+        )
+        check(
+          query,
+          "INSERT INTO json_table (id, data, data_json) VALUES (?, ?, ?)"
+        )
+      }
+    }
   }
 }

--- a/scalasql/test/src/dialects/PostgresJsonTests.scala
+++ b/scalasql/test/src/dialects/PostgresJsonTests.scala
@@ -2,6 +2,7 @@ package scalasql.dialects
 
 import scalasql._
 import scalasql.core.Expr
+import scalasql.dialects.PostgresDialect._
 import utest._
 import utils.ScalaSqlSuite
 import ujson.Value
@@ -19,10 +20,12 @@ trait PostgresJsonTests extends ScalaSqlSuite with PostgresDialect {
   }
 
   // Placeholder for checker required by ScalaSqlSuite, but we won't use it
-  def checker = ???
+  def checker: scalasql.utils.TestChecker = ???
 
   override def utestBeforeEach(path: Seq[String]): Unit = {}
   override def utestAfterEach(path: Seq[String]): Unit = {}
+
+  override implicit def UjsonQueryable: Queryable.Row[Expr[ujson.Value], ujson.Value] = new Expr.ExprQueryable()(UjsonValueType)
 
   case class JsonTable[T[_]](id: T[Int], data: T[ujson.Value], dataJson: T[ujson.Value])
   object JsonTable extends Table[JsonTable] {
@@ -120,7 +123,7 @@ trait PostgresJsonTests extends ScalaSqlSuite with PostgresDialect {
     test("insert") - {
       test("simple") - {
         val query = JsonTable.insert.values(
-          JsonTable(
+          JsonTable[Sc](
             id = 3,
             data = ujson.Obj("x" -> 10),
             dataJson = ujson.Obj("y" -> 20)

--- a/scalasql/test/src/dialects/PostgresJsonTests.scala
+++ b/scalasql/test/src/dialects/PostgresJsonTests.scala
@@ -1,0 +1,130 @@
+package scalasql.dialects
+
+import scalasql._
+import scalasql.core.Expr
+import utest._
+import utils.ScalaSqlSuite
+import ujson.Value
+
+trait PostgresJsonTests extends ScalaSqlSuite with PostgresDialect {
+  def description = "JSON operations"
+
+  // Mock DB for SQL generation checks only
+  lazy val mockDb = new DbClient.Connection(null, new Config {})
+
+  def check[Q, R](query: Q, sql: String)(implicit qr: Queryable[Q, R]) = {
+    val result = mockDb.renderSql(query)
+    val expected = sql.trim.replaceAll("\\s+", " ")
+    assert(result == expected)
+  }
+
+  // Placeholder for checker required by ScalaSqlSuite, but we won't use it
+  def checker = ???
+
+  override def utestBeforeEach(path: Seq[String]): Unit = {}
+  override def utestAfterEach(path: Seq[String]): Unit = {}
+
+  case class JsonTable[T[_]](id: T[Int], data: T[ujson.Value], dataJson: T[ujson.Value])
+  object JsonTable extends Table[JsonTable] {
+     override def tableName = "json_table"
+     override def tableColumnNameOverride(s: String) = s match {
+       case "dataJson" => "data_json"
+       case s => s
+     }
+  }
+
+  def tests = Tests {
+     test("access") - {
+         test("key") - check(
+            query = JsonTable.select.map(t => t.data -> "a"),
+            sql = "SELECT json_table0.data -> ? AS res FROM json_table json_table0"
+         )
+         test("index") - check(
+            query = JsonTable.select.map(t => t.data -> 0),
+            sql = "SELECT json_table0.data -> ? AS res FROM json_table json_table0"
+         )
+         test("keyText") - check(
+            query = JsonTable.select.map(t => t.data ->> "b"),
+            sql = "SELECT json_table0.data ->> ? AS res FROM json_table json_table0"
+         )
+         test("indexText") - check(
+            query = JsonTable.select.map(t => t.data ->> 1),
+            sql = "SELECT json_table0.data ->> ? AS res FROM json_table json_table0"
+         )
+         test("path") - check(
+            query = JsonTable.select.map(t => t.data #> "a"),
+            sql = "SELECT json_table0.data #> ARRAY[?] AS res FROM json_table json_table0"
+         )
+         test("pathText") - check(
+            query = JsonTable.select.map(t => t.data #>> "b"),
+            sql = "SELECT json_table0.data #>> ARRAY[?] AS res FROM json_table json_table0"
+         )
+     }
+
+     test("contains") - {
+         test("right") - check(
+            query = JsonTable.select.filter(t => t.data @> ujson.Obj("a" -> 1)).map(_.id),
+            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE json_table0.data @> ?"
+         )
+         test("left") - check(
+            query = JsonTable.select.filter(t => t.data <@ ujson.Arr(1, 2, 3)).map(_.id),
+            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE json_table0.data <@ ?"
+         )
+     }
+
+     test("exists") - {
+         test("key") - check(
+            query = JsonTable.select.filter(t => t.data ? "a").map(_.id),
+            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists(json_table0.data, ?)"
+         )
+         test("any") - check(
+            query = JsonTable.select.filter(t => t.data ?| ("a", "z")).map(_.id),
+            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists_any(json_table0.data, ARRAY[?, ?])"
+         )
+         test("all") - check(
+            query = JsonTable.select.filter(t => t.data ?& ("a", "b")).map(_.id),
+            sql = "SELECT json_table0.id AS res FROM json_table json_table0 WHERE jsonb_exists_all(json_table0.data, ARRAY[?, ?])"
+         )
+     }
+
+     test("concat") - check(
+        query = JsonTable.select.filter(_.id === 1).map(t => t.data || ujson.Obj("c" -> 3)),
+        sql = "SELECT json_table0.data || ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
+     )
+
+     test("delete") - {
+         test("key") - check(
+            query = JsonTable.select.filter(_.id === 1).map(t => t.data - "b"),
+            sql = "SELECT json_table0.data - ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
+         )
+         test("index") - check(
+            query = JsonTable.select.filter(_.id === 2).map(t => t.data - 1),
+            sql = "SELECT json_table0.data - ? AS res FROM json_table json_table0 WHERE (json_table0.id = ?)"
+         )
+     }
+
+     test("json") - {
+         // Testing JSON type (non-binary)
+         test("access") - check(
+            query = JsonTable.select.map(t => t.dataJson -> "a"),
+            sql = "SELECT json_table0.data_json -> ? AS res FROM json_table json_table0"
+         )
+     }
+
+     test("insert") - {
+        test("simple") - {
+           val query = JsonTable.insert.values(
+               JsonTable(
+                   id = 3,
+                   data = ujson.Obj("x" -> 10),
+                   dataJson = ujson.Obj("y" -> 20)
+               )
+           )
+           check(
+               query,
+               "INSERT INTO json_table (id, data, data_json) VALUES (?, ?, ?)"
+           )
+        }
+     }
+  }
+}

--- a/scalasql/test/src/example/PostgresJsonExample.scala
+++ b/scalasql/test/src/example/PostgresJsonExample.scala
@@ -3,6 +3,7 @@ package scalasql.example
 import org.testcontainers.containers.PostgreSQLContainer
 import scalasql.Table
 import scalasql.PostgresDialect._
+import scalasql.core.Expr
 import ujson.Value
 
 object PostgresJsonExample {
@@ -89,7 +90,7 @@ object PostgresJsonExample {
       // We compare it to ujson.Str("cat")
       val catLovers = db.run(
         Person.select
-          .filter(p => (p.info -> "pets" -> 0) === ujson.Str("cat"))
+          .filter(p => (p.info -> "pets" -> 0) === Expr[ujson.Value](ujson.Str("cat")))
           .map(_.name)
       )
       assert(catLovers == Seq("John"))

--- a/scalasql/test/src/example/PostgresJsonExample.scala
+++ b/scalasql/test/src/example/PostgresJsonExample.scala
@@ -1,0 +1,120 @@
+package scalasql.example
+
+import org.testcontainers.containers.PostgreSQLContainer
+import scalasql.Table
+import scalasql.PostgresDialect._
+import ujson.Value
+
+object PostgresJsonExample {
+
+  case class Person[T[_]](
+      id: T[Int],
+      name: T[String],
+      info: T[ujson.Value]
+  )
+
+  object Person extends Table[Person]
+
+  lazy val postgres = {
+    println("Initializing Postgres")
+    val pg = new PostgreSQLContainer("postgres:15-alpine")
+    pg.start()
+    pg
+  }
+
+  val dataSource = new org.postgresql.ds.PGSimpleDataSource
+  dataSource.setURL(postgres.getJdbcUrl)
+  dataSource.setDatabaseName(postgres.getDatabaseName);
+  dataSource.setUser(postgres.getUsername);
+  dataSource.setPassword(postgres.getPassword);
+
+  lazy val postgresClient = new scalasql.DbClient.DataSource(
+    dataSource,
+    config = new scalasql.Config {}
+  )
+
+  def main(args: Array[String]): Unit = {
+    postgresClient.transaction { db =>
+      db.updateRaw("""
+      CREATE TABLE person (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(256),
+          info JSONB
+      );
+      """)
+
+      val inserted = db.run(
+        Person.insert.batched(_.name, _.info)(
+          ("John", ujson.Obj("age" -> 30, "pets" -> ujson.Arr("cat", "dog"), "active" -> true)),
+          ("Jane", ujson.Obj("age" -> 25, "pets" -> ujson.Arr(), "active" -> false)),
+          ("Bob", ujson.Obj("age" -> 40, "pets" -> ujson.Arr("fish"), "active" -> true))
+        )
+      )
+
+      assert(inserted == 3)
+
+      // Select with filter using JSON operator -> and casting
+      // Find people older than 28
+      // Note: -> returns JSON, so we cast to Int for comparison if we extracted as text,
+      // but here we can rely on ujson comparison if we implement it,
+      // or easier: extract as text and cast, or use @> for containment
+
+      // Using ->> to get text and cast to integer
+      val seniors = db.run(
+        Person.select
+          .filter(p => (p.info ->> "age").cast[Int] > 28)
+          .map(_.name)
+      )
+      assert(seniors.toSet == Set("John", "Bob"))
+
+      // Using @> (contains)
+      // Find people who are active
+      val active = db.run(
+        Person.select
+          .filter(p => p.info @> ujson.Obj("active" -> true))
+          .map(_.name)
+      )
+      assert(active.toSet == Set("John", "Bob"))
+
+      // Using ? (exists key)
+      // Find people who have "pets" key (all of them)
+      val hasPets = db.run(
+        Person.select.filter(p => p.info ? "pets").size
+      )
+      assert(hasPets == 3)
+
+      // Using -> and index access
+      // Find people whose first pet is "cat"
+      // p.info -> "pets" gives the array. -> 0 gives the first element.
+      // We compare it to ujson.Str("cat")
+      val catLovers = db.run(
+        Person.select
+          .filter(p => (p.info -> "pets" -> 0) === ujson.Str("cat"))
+          .map(_.name)
+      )
+      assert(catLovers == Seq("John"))
+
+      // Update
+      // Add a new field "city": "New York" to John
+      db.run(
+        Person.update(_.name === "John")
+          .set(p => p.info := (p.info || ujson.Obj("city" -> "New York")))
+      )
+
+      val johnInfo = db.run(Person.select.filter(_.name === "John").single).info
+      assert(johnInfo("city").str == "New York")
+      assert(johnInfo("age").num == 30)
+
+      // Delete key
+      // Remove "active" field from Jane
+      db.run(
+         Person.update(_.name === "Jane")
+           .set(p => p.info := (p.info - "active"))
+      )
+
+      val janeInfo = db.run(Person.select.filter(_.name === "Jane").single).info
+      assert(!janeInfo.obj.contains("active"))
+      assert(janeInfo("age").num == 25)
+    }
+  }
+}

--- a/scalasql/test/src/example/PostgresJsonExample.scala
+++ b/scalasql/test/src/example/PostgresJsonExample.scala
@@ -97,7 +97,8 @@ object PostgresJsonExample {
       // Update
       // Add a new field "city": "New York" to John
       db.run(
-        Person.update(_.name === "John")
+        Person
+          .update(_.name === "John")
           .set(p => p.info := (p.info || ujson.Obj("city" -> "New York")))
       )
 
@@ -108,8 +109,9 @@ object PostgresJsonExample {
       // Delete key
       // Remove "active" field from Jane
       db.run(
-         Person.update(_.name === "Jane")
-           .set(p => p.info := (p.info - "active"))
+        Person
+          .update(_.name === "Jane")
+          .set(p => p.info := (p.info - "active"))
       )
 
       val janeInfo = db.run(Person.select.filter(_.name === "Jane").single).info


### PR DESCRIPTION
I lack the expertise to judge the quality of this code. 

If this is not the right approach, please feel free to close this PR.

I apologize if this is noise.

Original PR comment:

> This PR adds support for `json` and `jsonb` columns in Postgres dialect using `ujson.Value`.
> It includes a TypeMapper and a set of operators corresponding to Postgres JSON operators.
> Tests are added to verify the generated SQL.
> Note: Running tests against a real Postgres instance was not possible in the environment, so tests rely on verifying generated SQL strings.
> The `?` operators are implemented using `jsonb_exists` functions to avoid conflicts with JDBC parameter placeholders.
> 
> ---
> *PR created automatically by Jules for task [11001438534513701997](https://jules.google.com/task/11001438534513701997) started by @gabrieljones*