### PR TITLE
feat(tx): FP-friendly resource-block API [closes #99]

### DIFF
--- a/scalasql/core/src/DbApi.scala
+++ b/scalasql/core/src/DbApi.scala
@@ -194,12 +194,12 @@ object DbApi {
   trait Txn extends DbApi {
 
     /**
-     * Creates a SQL Savepoint that is active within the given block; automatically
+     * Returns a ResourceBlock that creates a SQL Savepoint that is active within the given block; automatically
      * releases the savepoint if the block completes successfully and rolls it back
      * if the block terminates with an exception, and allows you to roll back the
      * savepoint manually via the [[DbApi.Savepoint]] parameter passed to that block
      */
-    def savepoint[T](block: DbApi.Savepoint => T): T
+    def savepoint: UseBlock[DbApi.Savepoint]
 
     /**
      * Rolls back any active Savepoints and then rolls back this Transaction
@@ -575,31 +575,28 @@ object DbApi {
       DbApi.renderSql(query, config, dialect.withCastParams(castParams))
     }
 
-    val savepointStack = collection.mutable.ArrayDeque.empty[java.sql.Savepoint]
+    private val savepointStack = collection.mutable.ArrayDeque.empty[java.sql.Savepoint]
 
-    def savepoint[T](block: DbApi.Savepoint => T): T = {
-      val savepoint = connection.setSavepoint()
-      savepointStack.append(savepoint)
-
-      try {
-        val res = block(new DbApi.SavepointImpl(savepoint, () => rollbackSavepoint(savepoint)))
-        if (dialect.supportSavepointRelease && savepointStack.lastOption.exists(_ eq savepoint)) {
-          // Only release if this savepoint has not been rolled back,
-          // directly or indirectly
-          connection.releaseSavepoint(savepoint)
-        }
-        res
-      } catch {
-        case e: Throwable =>
-          rollbackSavepoint(savepoint)
-          throw e
+    lazy val savepoint: UseBlock[DbApi.Savepoint] = UseBlockImpl {
+      val jSavepoint = connection.setSavepoint()
+      savepointStack.append(jSavepoint)
+      jSavepoint
+    }((jSp, error) => {
+      error match {
+        case None =>
+          if (dialect.supportSavepointRelease && savepointStack.lastOption.exists(_ eq jSp)) {
+            // Only release if this savepoint has not been rolled back,
+            // directly or indirectly
+            connection.releaseSavepoint(jSp)
+          }
+        case Some(_) => rollbackSavepoint(jSp)
       }
-    }
+    }).map(jSp => new DbApi.SavepointImpl(jSp, () => rollbackSavepoint(jSp)))
 
     // Make sure we keep track of what savepoints are active on the stack, so we do
     // not release or rollback the same savepoint multiple times even in the case of
     // exceptions or explicit rollbacks
-    def rollbackSavepoint(savepoint: java.sql.Savepoint) = {
+    private def rollbackSavepoint(savepoint: java.sql.Savepoint) = {
       savepointStack.indexOf(savepoint) match {
         case -1 => // do nothing
         case savepointIndex =>
@@ -608,7 +605,7 @@ object DbApi {
       }
     }
 
-    def rollback() = {
+    def rollback(): Unit = {
       try {
         notifyListeners(listeners)(_.beforeRollback())
       } finally {
@@ -617,6 +614,11 @@ object DbApi {
         notifyListeners(listeners)(_.afterRollback())
       }
     }
+
+    /** Attempts rollback, adding any exceptions as suppressed to the cause */
+    def rollbackCause(cause: Throwable): Unit =
+      try rollback()
+      catch { case e: Throwable => cause.addSuppressed(e) }
 
     private def cast[T](t: Any): T = t.asInstanceOf[T]
 

--- a/scalasql/core/src/DbApi.scala
+++ b/scalasql/core/src/DbApi.scala
@@ -194,7 +194,7 @@ object DbApi {
   trait Txn extends DbApi {
 
     /**
-     * Returns a ResourceBlock that creates a SQL Savepoint that is active within the given block; automatically
+     * Returns a [[UseBlock]] that creates a SQL Savepoint that is active within the given block; automatically
      * releases the savepoint if the block completes successfully and rolls it back
      * if the block terminates with an exception, and allows you to roll back the
      * savepoint manually via the [[DbApi.Savepoint]] parameter passed to that block

--- a/scalasql/core/src/UseBlock.scala
+++ b/scalasql/core/src/UseBlock.scala
@@ -1,0 +1,87 @@
+package scalasql.core
+
+/**
+ * A block abstraction that wraps resource usage with proper acquiring and close/release.
+ * Exposes lifecycle operations separately, which is useful for integration with FP effect libraries.
+ * Should not be implemented outside of library code, so sealed.
+ *
+ * @tparam A The resource type provided during the `use` phase
+ */
+sealed trait UseBlock[+A] {
+
+  /**
+   * Acquires the resource. Called once at the start of the block.
+   * @return The acquired resource and release function.
+   */
+  def allocate(): (A, Option[Throwable] => Unit)
+
+  /**
+   * Combines acquire, use, and release into a single operation.
+   * Makes it friendly to traditional block-style API.
+   */
+  final def apply[T](use: A => T): T = {
+    val (resource, release) = allocate()
+    var usedOk = false
+    try {
+      val result = use(resource)
+      usedOk = true
+      release(None)
+      result
+    } catch {
+      case e: Throwable =>
+        if (!usedOk) {
+          release(Some(e))
+        } // else - we had an error in `release(None)`, so just propagating
+        throw e
+    }
+  }
+}
+
+/** Package-private implementation for internal composition */
+private[core] class UseBlockImpl[+A](alloc: () => (A, Option[Throwable] => Unit))
+    extends UseBlock[A] {
+
+  def allocate(): (A, Option[Throwable] => Unit) = alloc()
+
+  def map[B](f: A => B): UseBlockImpl[B] = new UseBlockImpl[B](() => {
+    val (a, release) = alloc()
+    (f(a), release)
+  })
+
+  def flatMap[B](f: A => UseBlock[B]): UseBlockImpl[B] = new UseBlockImpl[B](() => {
+    val (outerResource, outerRelease) = alloc()
+    val (innerResource, innerRelease) =
+      try {
+        f(outerResource).allocate()
+      } catch {
+        case e: Throwable =>
+          outerRelease(Some(e))
+          throw e
+      }
+    def combinedRelease(errOpt: Option[Throwable]): Unit = {
+      var errorForOuter = errOpt
+      try {
+        innerRelease(errOpt)
+      } catch {
+        case e: Throwable =>
+          errorForOuter = Some(e)
+          throw e
+      } finally {
+        outerRelease(errorForOuter)
+      }
+    }
+    (innerResource, combinedRelease)
+  })
+}
+
+private[core] object UseBlockImpl {
+
+  def apply[A](acquire: => A)(release: (A, Option[Throwable]) => Unit): UseBlockImpl[A] =
+    new UseBlockImpl[A](() => {
+      val a = acquire
+      (a, errOpt => release(a, errOpt))
+    })
+
+  def autoCloseable[A <: AutoCloseable](acquire: => A): UseBlockImpl[A] =
+    apply(acquire)((a, _) => a.close())
+}

--- a/scalasql/test/src/api/TransactionTests.scala
+++ b/scalasql/test/src/api/TransactionTests.scala
@@ -587,6 +587,27 @@ trait TransactionTests extends ScalaSqlSuite {
       }
     }
 
+    test("useBlock") - checker.recorded(
+      """
+      Both `transaction` and `savepoint` accessors are actually returning a special `UseBlock[...]` types.
+      When you call `transaction(use)` it desugars into `transaction.apply(use)` that provides a default
+      resource-style management - it creates a transaction (or savepoint), runs `use` block immediately, then releases
+      (commits or rolls back) the transaction.
+
+      If you need more control over the lifecycle, you may use transaction.allocate() method that returns
+      `(resource, releaseFunction)` pair.
+      This is especially useful when delaying side-effects with FP libraries like cats-effect or ZIO.
+      **Important:** `allocate()` is impure and must be delayed in that case also.
+      The `dbClient.transaction` expression itself does not perform any side-effects, it just creates closures.
+      """,
+      Text {
+        val transactionBlock: scalasql.core.UseBlock[DbApi.Txn] = dbClient.transaction
+
+        def createTransactionWithReleseFunction(): (DbApi.Txn, Option[Throwable] => Unit) =
+          transactionBlock.allocate()
+      }
+    )
+
     test("listener") {
       test("beforeCommit and afterCommit are called under normal circumstances") {
         val listener = new StubTransactionListener()

--- a/scalasql/test/src/api/TransactionTests.scala
+++ b/scalasql/test/src/api/TransactionTests.scala
@@ -603,7 +603,7 @@ trait TransactionTests extends ScalaSqlSuite {
       Text {
         val transactionBlock: scalasql.core.UseBlock[DbApi.Txn] = dbClient.transaction
 
-        def createTransactionWithReleseFunction(): (DbApi.Txn, Option[Throwable] => Unit) =
+        def createTxWithExitCallback(): (DbApi.Txn, Option[Throwable] => Unit) =
           transactionBlock.allocate()
       }
     )


### PR DESCRIPTION
The rationale is already discussed in #99.

This will significantly help with pure effect delaying libraries (cats.effect, ZIO).

Without separation, one have to access block api and run the result using the effect runtime / event loop (a top-level thing).
With this operations being separated, FP interop library can just delay acquiring and release and use their own combinators to compose something similar to what `UseBlock.apply` does.

The change is source-compatible, but not binary compatible. If it's a concern, I can simply add an extra method and adjust to something like:

```scala
def transactionBlock: UseBlock[DbApi.Txn]
final def transaction[T](block: DbApi.Txn => T): T = transactionBlock(block)
``` 